### PR TITLE
Fixing issue #16

### DIFF
--- a/src/main/resources/data/natures_delight/recipe/cooking/alfredo_pasta.json
+++ b/src/main/resources/data/natures_delight/recipe/cooking/alfredo_pasta.json
@@ -7,7 +7,7 @@
       "item": "farmersdelight:chicken_cuts"
     },
     {
-      "tag": "c:foods/pastas"
+      "tag": "c:foods/pasta"
     },
     {
       "item": "natures_spirit:cheese_bucket"

--- a/src/main/resources/data/natures_delight/recipe/cooking/cocada.json
+++ b/src/main/resources/data/natures_delight/recipe/cooking/cocada.json
@@ -7,7 +7,7 @@
       "item": "natures_spirit:coconut_half"
     },
     {
-      "tag": "c:milks"
+      "tag": "c:foods/milk"
     },
     {
       "item": "minecraft:sugar"

--- a/src/main/resources/data/natures_delight/recipe/cooking/coconut_pancakes.json
+++ b/src/main/resources/data/natures_delight/recipe/cooking/coconut_pancakes.json
@@ -7,7 +7,7 @@
       "item": "natures_spirit:coconut_half"
     },
     {
-      "tag": "c:milks"
+      "tag": "c:foods/milk"
     },
     {
       "item": "farmersdelight:rice"


### PR DESCRIPTION
I managed to fix the alfredo pasta, coconut pancakes and cocada crafting recipes - [apparently fabric updated the conventions for c: tags, and farmer's delight for 1.21 followed.](https://github.com/MerchantCalico/FarmersDelight/tree/fix/1.21/tag-soup/src/generated/resources/data/c/tags/item/foods) Unfortunately I could not find the rules for these new conventions anywhere, but at least our crafting recipes are functional now.